### PR TITLE
Fix tag URL generation in post layout

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,9 +21,9 @@ post_class: post-template
                         {% if page.tags.size > 0 %}
                         <div class="tag-links">
                             {% for tag in page.tags %} {% if forloop.index == page.tags.size %}
-                            <a href='{{ site.baseurl }}tag/{{ tag | downcase | replace: ' ', '- ' }}/'>{{ tag | camelcase }}</a>
+                            <a href='{{ site.baseurl }}/tag/{{ tag | downcase | replace: ' ', '-' }}/'>{{ tag | camelcase }}</a>
                             {% else %}
-                            <a href='{{ site.baseurl }}tag/{{ tag | downcase | replace: ' ', '- ' }}/'>{{ tag | camelcase }}</a>
+                            <a href='{{ site.baseurl }}/tag/{{ tag | downcase | replace: ' ', '-' }}/'>{{ tag | camelcase }}</a>
                             {% endif %}
                             {% endfor %}
                         </div><!-- .tag-links -->


### PR DESCRIPTION
## Summary
Fixed tag URL generation in the post layout template to correctly format tag slugs and ensure proper URL structure.

## Key Changes
- Added missing forward slash after `site.baseurl` in tag links to ensure correct URL paths
- Changed tag slug spacing from `'- '` (hyphen with space) to `'-'` (hyphen only) to generate valid URL-friendly slugs
- Applied fixes to both conditional branches (last tag and other tags)

## Implementation Details
The changes ensure that:
1. Tag URLs are properly formed with correct path separators (e.g., `/tag/example-tag/` instead of `tag/example-tag/`)
2. Multi-word tags are converted to valid URL slugs with single hyphens as separators (e.g., `my tag` becomes `my-tag` instead of `my- tag`)

https://claude.ai/code/session_016mzpY1yZ1RA4U8ZfZu7SSg