### PR TITLE
Add local tag page generator plugin

### DIFF
--- a/_plugins/tag_generator.rb
+++ b/_plugins/tag_generator.rb
@@ -1,0 +1,45 @@
+module Jekyll
+  # Generates paginated tag pages at /tag/{slug}/ for every tag used in posts.
+  # This replaces the jekyll-tagsgenerator gem with a local plugin that is
+  # always loaded by Jekyll regardless of gem availability.
+  class LocalTagsGenerator < Generator
+    safe true
+
+    def generate(site)
+      site.tags.each do |tag|
+        build_subpages(site, "tag", tag)
+      end
+    end
+
+    def build_subpages(site, type, posts)
+      posts[1] = posts[1].sort_by { |p| -p.date.to_f }
+      paginate(site, type, posts)
+    end
+
+    def paginate(site, type, posts)
+      pages = Jekyll::Paginate::Pager.calculate_pages(posts[1], site.config['paginate'].to_i)
+      (1..pages).each do |num_page|
+        pager = Jekyll::Paginate::Pager.new(site, num_page, posts[1], pages)
+        path = "/tag/#{posts[0]}".gsub(' ', '-').downcase
+        path = path + "/page#{num_page}" if num_page > 1
+        newpage = LocalTagPage.new(site, site.source, path, type, posts[0])
+        newpage.pager = pager
+        site.pages << newpage
+      end
+    end
+  end
+
+  class LocalTagPage < Page
+    def initialize(site, base, dir, type, val)
+      @site = site
+      @base = base
+      @dir  = dir
+      @name = 'index.html'
+
+      self.process(@name)
+      self.read_yaml(File.join(base, '_layouts'), 'tag.html')
+      self.data['grouptype'] = type
+      self.data[type] = val
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This change adds a local Jekyll plugin that generates paginated tag archive pages, replacing the external `jekyll-tagsgenerator` gem dependency with an always-available built-in solution.

## Key Changes
- **New plugin file**: `_plugins/tag_generator.rb` implements tag page generation
  - `LocalTagsGenerator` class iterates through all site tags and generates paginated pages
  - `LocalTagPage` class creates individual tag archive pages using the `tag.html` layout
  - Tag pages are generated at `/tag/{slug}/` with pagination support (e.g., `/tag/{slug}/page2/`)
  - Posts within each tag are sorted by date in descending order
  - Tag slugs are normalized (spaces converted to hyphens, lowercase)

## Implementation Details
- The plugin uses Jekyll's built-in `Paginate::Pager` for pagination logic
- Each tag page receives `grouptype` and the tag name as template variables
- The plugin is marked as `safe true` for compatibility with Jekyll's safe mode
- This eliminates the need for external gem dependencies while maintaining the same functionality

https://claude.ai/code/session_01KdMHfwJBGzCBTKkjhKgwnW